### PR TITLE
Added a check for updating the overlap availability state.

### DIFF
--- a/web/src/containers/app/lib/InteractiveOverlay.tsx
+++ b/web/src/containers/app/lib/InteractiveOverlay.tsx
@@ -353,6 +353,9 @@ export class Component extends React.Component<PropsUnion, State> {
 	public scrollableTravelTimesContainer = React.createRef<HTMLDivElement>()
 
 	public componentDidUpdate(prevProps: Readonly<PropsUnion>, prevState: Readonly<State>, snapshot?: any): void {
+		if (this.props.overlap && this.props.overlap.shapes[0].shell.length === 0 && this.props.overlapVisible) {
+			this.props.setOverlapState(false)
+		}
 		if (this.props.newTravelTimeDetails !== prevProps.newTravelTimeDetails) {
 			this.setState({isCurrentlyAddingNewTravelTime: true})
 


### PR DESCRIPTION
This pull request aims to fix an issue with the overlap being active while a newly calculated intersection makes this impossible.

This problem occurs when the overlap toggle is active and a new travel-time is added, this added travel-time must not have any overlap with the previous overlap area. When the new travel-time data is merged with the previous state the overlap toggle is rightfully disabled, unfortunately the user is now locked in an unavailable state.

Fixes PROD-50